### PR TITLE
update Python to 3.9

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,12 +1,11 @@
-FROM python:3-alpine
+FROM python:3.9-alpine@sha256:02311d686cd35b0f838854d6035c679acde2767a4fd09904e65355fbd9780f8a
 
 WORKDIR /usr/src/app
 EXPOSE 8080
 
-RUN pip install --no-cache-dir tornado
-RUN pip install --no-cache-dir docker
-
 COPY . .
+
+RUN python -m pip install -r requirements.txt --user
 
 ENTRYPOINT [ "python", "./management-service.py" ]
 CMD []

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,0 +1,3 @@
+tornado==6.1
+six==1.15.0
+docker==4.4.4


### PR DESCRIPTION
Set the Docker base image for the management service to a fixed version, this has led to Python updates breaking tinyFaaS. Should fix #13 