### PR TITLE
Log Actual Async Header

### DIFF
--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -21,7 +21,7 @@ func Start(r *rproxy.RProxy, listenAddr string) {
 
 		async := req.Header.Get("X-tinyFaaS-Async") != ""
 
-		log.Printf("have request for path: %s (async: %v)", p, false)
+		log.Printf("have request for path: %s (async: %v)", p, async)
 
 		req_body, err := io.ReadAll(req.Body)
 


### PR DESCRIPTION
This is just a tiny fix for logging in the http module.

Changes:

1. Update the `http` module to log the async header value