### PR TITLE
add http/grpc header support for py/js functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Additionally, we provide scripts to read logs from your function and to wipe all
 ### Writing Functions
 
 This tinyFaaS prototype only supports functions written for NodeJS 20, Python 3.9, and binary functions.
+HTTP headers and GRPC Metadata are accessible in NodeJS and Python functions as key values. Check the example functions below for more information.
 
 #### NodeJS 20
 

--- a/pkg/coap/coap.go
+++ b/pkg/coap/coap.go
@@ -8,6 +8,8 @@ import (
 	"github.com/pfandzelter/go-coap"
 )
 
+const async = false
+
 func Start(r *rproxy.RProxy, listenAddr string) {
 
 	h := coap.FuncHandler(
@@ -17,8 +19,6 @@ func Start(r *rproxy.RProxy, listenAddr string) {
 			log.Printf("is confirmable: %v", m.IsConfirmable())
 			log.Printf("path: %s", m.PathString())
 
-			async := false
-
 			p := m.PathString()
 
 			for p != "" && p[0] == '/' {
@@ -27,7 +27,7 @@ func Start(r *rproxy.RProxy, listenAddr string) {
 
 			log.Printf("have request for path: %s (async: %v)", p, async)
 
-			s, res := r.Call(p, m.Payload, async)
+			s, res := r.Call(p, m.Payload, async, nil)
 
 			mes := &coap.Message{
 				Type:      coap.Acknowledgement,

--- a/pkg/docker/runtimes/python3/functionhandler.py
+++ b/pkg/docker/runtimes/python3/functionhandler.py
@@ -32,8 +32,11 @@ if __name__ == "__main__":
             if d == "":
                 d = None
 
+            # Read headers into a dictionary
+            headers: typing.Dict[str, str] = {k: v for k, v in self.headers.items()}
+
             try:
-                res = fn.fn(d)
+                res = fn.fn(d, headers)
                 self.send_response(200)
                 self.end_headers()
                 if res is not None:

--- a/pkg/grpc/grpc.go
+++ b/pkg/grpc/grpc.go
@@ -9,6 +9,7 @@ import (
 	"github.com/OpenFogStack/tinyFaaS/pkg/grpc/tinyfaas"
 	"github.com/OpenFogStack/tinyFaaS/pkg/rproxy"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 // GRPCServer is the grpc endpoint for this tinyFaaS instance.
@@ -21,7 +22,21 @@ func (gs *GRPCServer) Request(ctx context.Context, d *tinyfaas.Data) (*tinyfaas.
 
 	log.Printf("have request for path: %s (async: %v)", d.FunctionIdentifier, false)
 
-	s, res := gs.r.Call(d.FunctionIdentifier, []byte(d.Data), false)
+	// Extract metadata from the gRPC context
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("failed to extract metadata from context")
+	}
+
+	// Convert metadata to map[string]string
+	headers := make(map[string]string)
+	for k, v := range md {
+		if len(v) > 0 {
+			headers[k] = v[0]
+		}
+	}
+
+	s, res := gs.r.Call(d.FunctionIdentifier, []byte(d.Data), false, headers)
 
 	switch s {
 	case rproxy.StatusOK:

--- a/pkg/grpc/grpc.go
+++ b/pkg/grpc/grpc.go
@@ -24,16 +24,16 @@ func (gs *GRPCServer) Request(ctx context.Context, d *tinyfaas.Data) (*tinyfaas.
 
 	// Extract metadata from the gRPC context
 	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		return nil, fmt.Errorf("failed to extract metadata from context")
-	}
-
-	// Convert metadata to map[string]string
 	headers := make(map[string]string)
-	for k, v := range md {
-		if len(v) > 0 {
-			headers[k] = v[0]
+	if ok {
+		// Convert metadata to map[string]string
+		for k, v := range md {
+			if len(v) > 0 {
+				headers[k] = v[0]
+			}
 		}
+	} else {
+		log.Print("failed to extract metadata from context, using empty headers GRPC request")
 	}
 
 	s, res := gs.r.Call(d.FunctionIdentifier, []byte(d.Data), false, headers)

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -31,7 +31,12 @@ func Start(r *rproxy.RProxy, listenAddr string) {
 			return
 		}
 
-		s, res := r.Call(p, req_body, async)
+		headers := make(map[string]string)
+		for k, v := range req.Header {
+			headers[k] = v[0]
+		}
+
+		s, res := r.Call(p, req_body, async, headers)
 
 		switch s {
 		case rproxy.StatusOK:

--- a/pkg/rproxy/rproxy.go
+++ b/pkg/rproxy/rproxy.go
@@ -75,11 +75,11 @@ func (r *RProxy) Call(name string, payload []byte, async bool, headers map[strin
 
 	log.Printf("chosen handler: %s", h)
 
+	req, err := http.NewRequest("POST", fmt.Sprintf("http://%s:8000/fn", h), bytes.NewBuffer(payload))
 	// call function
 	if async {
 		log.Printf("async request accepted")
 		go func() {
-			req, err := http.NewRequest("POST", fmt.Sprintf("http://%s:8000/fn", h), bytes.NewBuffer(payload))
 			if err != nil {
 				return
 			}
@@ -98,7 +98,7 @@ func (r *RProxy) Call(name string, payload []byte, async bool, headers map[strin
 
 	// call function and return results
 	log.Printf("sync request starting")
-	req, err := http.NewRequest("POST", fmt.Sprintf("http://%s:8000/fn", h), bytes.NewBuffer(payload))
+
 	if err != nil {
 		log.Print(err)
 		return StatusError, nil

--- a/test/fns/echo-js/index.js
+++ b/test/fns/echo-js/index.js
@@ -1,7 +1,9 @@
 
 module.exports = (req, res) => {
   const response = req.body;
+  const headers = req.headers; // headers from the http request or GRPC metadata
 
+  console.log("Headers:", headers);
   console.log(response);
 
   res.send(response); 

--- a/test/fns/echo/fn.py
+++ b/test/fns/echo/fn.py
@@ -2,6 +2,9 @@
 
 import typing
 
-def fn(input: typing.Optional[str]) -> typing.Optional[str]:
+def fn(input: typing.Optional[str], headers: typing.Optional[typing.Dict[str, str]]) -> typing.Optional[str]:
     """echo the input"""
+    if headers is not None:
+        print ("headers: " + str(headers))
+
     return input

--- a/test/fns/show-headers-js/index.js
+++ b/test/fns/show-headers-js/index.js
@@ -1,9 +1,9 @@
 
 module.exports = (req, res) => {
-  const response = req.body;
+  const body = req.body;
   const headers = req.headers; // headers from the http request or GRPC metadata
 
-  console.log(response);
+  console.log("Headers:", headers);
 
-  res.send(response); 
+  res.send(headers);
 }

--- a/test/fns/show-headers-js/package.json
+++ b/test/fns/show-headers-js/package.json
@@ -1,0 +1,1 @@
+{"name": "fn", "version": "1.0.0", "main": "index.js"}

--- a/test/fns/show-headers/fn.py
+++ b/test/fns/show-headers/fn.py
@@ -4,4 +4,11 @@ import typing
 
 def fn(input: typing.Optional[str], headers: typing.Optional[typing.Dict[str, str]]) -> typing.Optional[str]:
     """echo the input"""
-    return input
+    msg = ""
+    if headers is not None:
+        msg = str(headers)
+    else:
+        msg = "{}"
+
+
+    return msg

--- a/test/fns/show-headers/fn.py
+++ b/test/fns/show-headers/fn.py
@@ -1,14 +1,9 @@
-#!/usr/bin/env python3
-
+import json
 import typing
 
 def fn(input: typing.Optional[str], headers: typing.Optional[typing.Dict[str, str]]) -> typing.Optional[str]:
     """echo the input"""
-    msg = ""
     if headers is not None:
-        msg = str(headers)
+        return json.dumps(headers)
     else:
-        msg = "{}"
-
-
-    return msg
+        return "{}"

--- a/test/fns/sieve-of-eratosthenes/index.js
+++ b/test/fns/sieve-of-eratosthenes/index.js
@@ -1,7 +1,5 @@
 
 module.exports = (req, res) => {
-  const data = req.body;
-  const headers = req.headers; // headers from the http request or GRPC metadata
   const max = 10000;
   let sieve = [], i, j, primes = [];
   for (i = 2; i <= max; ++i) {
@@ -14,7 +12,7 @@ module.exports = (req, res) => {
     }
   }
 
-  response = ("Found " + primes.length + " primes under " + max);
+  let response = ("Found " + primes.length + " primes under " + max);
 
   console.log(response);
 

--- a/test/fns/sieve-of-eratosthenes/index.js
+++ b/test/fns/sieve-of-eratosthenes/index.js
@@ -1,5 +1,7 @@
 
 module.exports = (req, res) => {
+  const data = req.body;
+  const headers = req.headers; // headers from the http request or GRPC metadata
   const max = 10000;
   let sieve = [], i, j, primes = [];
   for (i = 2; i <= max; ++i) {

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -48,7 +48,7 @@ def setUpModule() -> None:
         uname = os.uname()
         if uname.machine == "x86_64":
             arch = "amd64"
-        elif uname.machine == "arm64":
+        elif uname.machine == "arm64" or uname.machine == "aarch64":
             arch = "arm64"
         else:
             raise Exception(f"Unsupported architecture: {uname.machine}")


### PR DESCRIPTION
- update function handler for python + JS
- pass grpc headers (metadata)
- pass http headers (http.go)
- update rproxy to pass the headers to function handlers
- test it to log print the headers
- update python and js examples
- update readme to mention this change
